### PR TITLE
Added arm64 support to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,26 @@ matrix:
     - pip install codespell
     script:
     - codespell --skip="vendor,*.git,*.png,*.pdf,*.tiff,*.plist,*.pem,rangesim*.go,*.gz" --ignore-words="./testdata/ignore_words.txt"
+  - language: python
+    arch: arm64
+    install:
+    - pip install codespell
+    script:
+    - codespell --skip="vendor,*.git,*.png,*.pdf,*.tiff,*.plist,*.pem,rangesim*.go,*.gz" --ignore-words="./testdata/ignore_words.txt"
 
   - language: go
+    go:
+    - "1.14.x"
+    - master
+    before_install:
+    - go get github.com/mattn/goveralls
+    - go mod vendor
+    script:
+    - make style test build
+    - sed -i -e '/^.*_gen\.go:.*$/d' .coverprofile
+    - $GOPATH/bin/goveralls  -coverprofile=.coverprofile -service=travis-ci
+  - language: go
+    arch: arm64
     go:
     - "1.14.x"
     - master


### PR DESCRIPTION
Hi

**Package Owner:** Rahul Aggarwal

**PR change Details:**
**Patch Details :** Following file has been modified :

.travis.yml : Both jobs (with python and Go: 1.14.x) are duplicated for arch: arm64

**Testing Detail :**
Please find my travis-ci testing jobs here : https://travis-ci.com/github/rahulgit-ps/trickster/builds/173852155

**Reviewer Comment :** < To be filled by Reviewer >

**PR Description :** Here is my commit message :
Added arm64 support to travis-ci

Added arm64 jobs (with python and Go: 1.14.x) in .travis.yml
**Reviewer Comment :** < To be filled by Reviewer >

**Peer Reviewer:** N/A
**Reviewer:** Rajeev Nayan

**Thanks
Rahul Aggarwal**

